### PR TITLE
[add] Implement custom error type for Todo not found

### DIFF
--- a/model/error.go
+++ b/model/error.go
@@ -1,0 +1,8 @@
+package model
+
+type ErrNotFound struct {
+}
+
+func (e *ErrNotFound) Error() string {
+	return "Todo not found"
+}


### PR DESCRIPTION
This pull request introduces a new error type to the `model` package for handling "not found" errors in a more structured way.

* [`model/error.go`](diffhunk://#diff-0895257c144527f8843d4799d14b870b997f5a401cdec8be36ccdfbad3a2f8a6R1-R8): Added a new `ErrNotFound` type with an `Error` method to return a "Todo not found" message.